### PR TITLE
Add Node.js quickstart for access control

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,6 +12,7 @@
 * [Testnets](for-developers/get-started-with-tac.md)
 * [Access Control](for-developers/access-control/README.md)
   * [Quickstart (Testnet)](for-developers/access-control/quickstart-testnet.md)
+  * [Quickstart — Node.js (Testnet)](for-developers/access-control/quickstart-nodejs.md)
   * [Integrate Into Apps](for-developers/access-control/taco-integration/README.md)
     * [Encryptor Allowlist](for-developers/access-control/taco-integration/encryptor-allowlist.md)
   * [Ecosystem Integrations](for-developers/access-control/integrations/README.md)

--- a/for-developers/access-control/quickstart-nodejs.md
+++ b/for-developers/access-control/quickstart-nodejs.md
@@ -21,7 +21,7 @@ npm install @nucypher/taco @nucypher/taco-auth ethers@5.7.2
 ```
 
 {% hint style="warning" %}
-TACo currently requires **ethers v5**. If you're using ethers v6, you'll need to install v5 alongside it or use the v5 compatibility layer.
+TACo currently requires **ethers v5**. The API is not compatible with ethers v6. If your project uses ethers v6, you must use `ethers@5.7.2` for TACo integration.
 {% endhint %}
 {% endstep %}
 
@@ -55,13 +55,14 @@ const ritualId = 6;
 ## Encrypt data
 
 ```typescript
-import { conditions, encrypt, initialize, toBytes } from '@nucypher/taco';
+import { conditions, encrypt, initialize } from '@nucypher/taco';
+import { ethers } from 'ethers';
 
 await initialize();
 
 // Any condition works — here's a simple balance check
 const hasBalance = new conditions.base.rpc.RpcCondition({
-  chain: 80002,  // Polygon Amoy (condition evaluation chain, not the DKG chain)
+  chain: 80002,  // Polygon Amoy — the chain where this condition is evaluated (can be any supported chain)
   method: 'eth_getBalance',
   parameters: [':userAddress', 'latest'],
   returnValueTest: {
@@ -98,14 +99,13 @@ import {
   ThresholdMessageKit,
   conditions,
   decrypt,
-  domains,
-  fromBytes,
   initialize,
 } from '@nucypher/taco';
 import {
   EIP4361AuthProvider,
   USER_ADDRESS_PARAM_DEFAULT,
 } from '@nucypher/taco-auth';
+import { ethers } from 'ethers';
 
 await initialize();
 
@@ -134,7 +134,7 @@ const decryptedBytes = await decrypt(
   conditionContext,
 );
 
-const decryptedMessage = fromBytes(decryptedBytes);
+const decryptedMessage = new TextDecoder().decode(decryptedBytes);
 console.log(decryptedMessage); // "my secret message"
 ```
 {% endstep %}

--- a/for-developers/access-control/quickstart-nodejs.md
+++ b/for-developers/access-control/quickstart-nodejs.md
@@ -1,0 +1,146 @@
+---
+description: >-
+  Encrypt and decrypt data with TACo in a Node.js environment — no browser or
+  wallet extension required.
+---
+
+# Quickstart — Node.js (Testnet)
+
+This guide walks through a complete encrypt → decrypt flow in Node.js. Unlike the browser quickstart, there's no MetaMask or `window.ethereum` — we use private keys and `JsonRpcProvider` directly.
+
+{% hint style="info" %}
+A full working example lives in the taco-web repo: [`examples/taco/nodejs`](https://github.com/nucypher/taco-web/tree/main/examples/taco/nodejs)
+{% endhint %}
+
+### 1. Installation
+
+```bash
+npm install @nucypher/taco @nucypher/taco-auth ethers@5.7.2
+```
+
+{% hint style="warning" %}
+TACo currently requires **ethers v5**. If you're using ethers v6, you'll need to install v5 alongside it or use the v5 compatibility layer.
+{% endhint %}
+
+### 2. Configuration
+
+You'll need three things:
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| **RPC URL** | A Polygon Amoy RPC endpoint | This reads DKG coordination contracts — it's **not** your application's chain. Any public Amoy RPC works (e.g. `https://polygon-amoy.drpc.org`). |
+| **Ritual ID** | `6` (for TAPIR testnet) | See the [testnets](../get-started-with-tac.md#threshold-decryption) page for other environments. |
+| **Private keys** | Two test wallets | One for the encryptor, one for the consumer. These can be any Ethereum wallets — no testnet funds required. |
+
+```typescript
+import { ethers } from 'ethers';
+import { domains } from '@nucypher/taco';
+
+// This provider reads DKG coordination contracts on Polygon Amoy.
+// It is NOT your application's RPC — it's infrastructure.
+const provider = new ethers.providers.JsonRpcProvider(
+  'https://polygon-amoy.drpc.org'
+);
+
+const domain = domains.TESTNET;  // "tapir"
+const ritualId = 6;
+```
+
+### 3. Encrypt
+
+```typescript
+import { conditions, encrypt, initialize, toBytes } from '@nucypher/taco';
+
+await initialize();
+
+// Any condition works — here's a simple balance check
+const hasBalance = new conditions.base.rpc.RpcCondition({
+  chain: 80002,  // Polygon Amoy (condition evaluation chain, not the DKG chain)
+  method: 'eth_getBalance',
+  parameters: [':userAddress', 'latest'],
+  returnValueTest: {
+    comparator: '>=',
+    value: 0,
+  },
+});
+
+const encryptorSigner = new ethers.Wallet('<ENCRYPTOR_PRIVATE_KEY>');
+
+const messageKit = await encrypt(
+  provider,
+  domain,
+  'my secret message',
+  hasBalance,
+  ritualId,
+  encryptorSigner,
+);
+
+// Serialize for storage or transmission
+const encryptedBytes = messageKit.toBytes();
+```
+
+{% hint style="warning" %}
+**Do not JSON-serialize `ThresholdMessageKit` directly** — it uses a custom binary format. Always use `.toBytes()` for serialization and `ThresholdMessageKit.fromBytes()` for deserialization. If you need to store it in JSON, encode the bytes as base64 or hex first.
+{% endhint %}
+
+### 4. Decrypt
+
+```typescript
+import {
+  ThresholdMessageKit,
+  conditions,
+  decrypt,
+  domains,
+  fromBytes,
+  initialize,
+} from '@nucypher/taco';
+import {
+  EIP4361AuthProvider,
+  USER_ADDRESS_PARAM_DEFAULT,
+} from '@nucypher/taco-auth';
+
+await initialize();
+
+// Deserialize
+const messageKit = ThresholdMessageKit.fromBytes(encryptedBytes);
+
+const consumerSigner = new ethers.Wallet('<CONSUMER_PRIVATE_KEY>');
+
+// Build condition context
+const conditionContext =
+  conditions.context.ConditionContext.fromMessageKit(messageKit);
+
+// In Node.js, EIP4361AuthProvider needs explicit SIWE parameters
+// (in the browser, these come from the page origin)
+const authProvider = new EIP4361AuthProvider(
+  provider,
+  consumerSigner,
+  { domain: 'localhost', uri: 'http://localhost:3000' },
+);
+conditionContext.addAuthProvider(USER_ADDRESS_PARAM_DEFAULT, authProvider);
+
+const decryptedBytes = await decrypt(
+  provider,
+  domain,
+  messageKit,
+  conditionContext,
+);
+
+const decryptedMessage = fromBytes(decryptedBytes);
+console.log(decryptedMessage); // "my secret message"
+```
+
+### Key differences from browser usage
+
+| Concern | Browser | Node.js |
+|---------|---------|---------|
+| **Provider** | `new ethers.providers.Web3Provider(window.ethereum)` | `new ethers.providers.JsonRpcProvider(rpcUrl)` |
+| **Signer** | `provider.getSigner()` (MetaMask popup) | `new ethers.Wallet(privateKey)` |
+| **SIWE auth** | Domain/URI inferred from page | Must pass `{ domain, uri }` explicitly |
+| **Serialization** | Often stays in memory | Use `messageKit.toBytes()` / `ThresholdMessageKit.fromBytes()` |
+
+### Next steps
+
+* Browse all [condition types](../taco-sdk/references/conditions/) to define more complex access rules
+* See the [full Node.js example](https://github.com/nucypher/taco-web/tree/main/examples/taco/nodejs) in the taco-web repo
+* Review [testnets](../get-started-with-tac.md) for ritual IDs and network configuration

--- a/for-developers/access-control/quickstart-nodejs.md
+++ b/for-developers/access-control/quickstart-nodejs.md
@@ -12,7 +12,9 @@ This guide walks through a complete encrypt → decrypt flow in Node.js. Unlike 
 A full working example lives in the taco-web repo: [`examples/taco/nodejs`](https://github.com/nucypher/taco-web/tree/main/examples/taco/nodejs)
 {% endhint %}
 
-### 1. Installation
+{% stepper %}
+{% step %}
+## Install dependencies
 
 ```bash
 npm install @nucypher/taco @nucypher/taco-auth ethers@5.7.2
@@ -21,16 +23,18 @@ npm install @nucypher/taco @nucypher/taco-auth ethers@5.7.2
 {% hint style="warning" %}
 TACo currently requires **ethers v5**. If you're using ethers v6, you'll need to install v5 alongside it or use the v5 compatibility layer.
 {% endhint %}
+{% endstep %}
 
-### 2. Configuration
+{% step %}
+## Configure provider, domain, and ritual ID
 
 You'll need three things:
 
 | Parameter | Value | Notes |
 |-----------|-------|-------|
-| **RPC URL** | A Polygon Amoy RPC endpoint | This reads DKG coordination contracts — it's **not** your application's chain. Any public Amoy RPC works (e.g. `https://polygon-amoy.drpc.org`). |
+| **RPC URL** | A Polygon Amoy RPC endpoint | This reads DKG coordination contracts — it's **not** your application's chain. Any public Amoy RPC works. |
 | **Ritual ID** | `6` (for TAPIR testnet) | See the [testnets](../get-started-with-tac.md#threshold-decryption) page for other environments. |
-| **Private keys** | Two test wallets | One for the encryptor, one for the consumer. These can be any Ethereum wallets — no testnet funds required. |
+| **Private keys** | Two test wallets | One for the encryptor, one for the consumer. Any Ethereum wallets — no testnet funds required. |
 
 ```typescript
 import { ethers } from 'ethers';
@@ -45,8 +49,10 @@ const provider = new ethers.providers.JsonRpcProvider(
 const domain = domains.TESTNET;  // "tapir"
 const ritualId = 6;
 ```
+{% endstep %}
 
-### 3. Encrypt
+{% step %}
+## Encrypt data
 
 ```typescript
 import { conditions, encrypt, initialize, toBytes } from '@nucypher/taco';
@@ -82,8 +88,10 @@ const encryptedBytes = messageKit.toBytes();
 {% hint style="warning" %}
 **Do not JSON-serialize `ThresholdMessageKit` directly** — it uses a custom binary format. Always use `.toBytes()` for serialization and `ThresholdMessageKit.fromBytes()` for deserialization. If you need to store it in JSON, encode the bytes as base64 or hex first.
 {% endhint %}
+{% endstep %}
 
-### 4. Decrypt
+{% step %}
+## Decrypt data
 
 ```typescript
 import {
@@ -129,17 +137,63 @@ const decryptedBytes = await decrypt(
 const decryptedMessage = fromBytes(decryptedBytes);
 console.log(decryptedMessage); // "my secret message"
 ```
+{% endstep %}
+{% endstepper %}
 
-### Key differences from browser usage
+## Key differences from browser usage
 
-| Concern | Browser | Node.js |
-|---------|---------|---------|
-| **Provider** | `new ethers.providers.Web3Provider(window.ethereum)` | `new ethers.providers.JsonRpcProvider(rpcUrl)` |
-| **Signer** | `provider.getSigner()` (MetaMask popup) | `new ethers.Wallet(privateKey)` |
-| **SIWE auth** | Domain/URI inferred from page | Must pass `{ domain, uri }` explicitly |
-| **Serialization** | Often stays in memory | Use `messageKit.toBytes()` / `ThresholdMessageKit.fromBytes()` |
+{% tabs %}
+{% tab title="Provider" %}
+**Browser:**
+```typescript
+const provider = new ethers.providers.Web3Provider(window.ethereum);
+```
 
-### Next steps
+**Node.js:**
+```typescript
+const provider = new ethers.providers.JsonRpcProvider('https://polygon-amoy.drpc.org');
+```
+{% endtab %}
+
+{% tab title="Signer" %}
+**Browser:**
+```typescript
+const signer = provider.getSigner(); // MetaMask popup
+```
+
+**Node.js:**
+```typescript
+const signer = new ethers.Wallet('<PRIVATE_KEY>');
+```
+{% endtab %}
+
+{% tab title="SIWE Auth" %}
+**Browser:** Domain and URI inferred from page origin.
+```typescript
+const authProvider = new EIP4361AuthProvider(provider, signer);
+```
+
+**Node.js:** Must pass `{ domain, uri }` explicitly.
+```typescript
+const authProvider = new EIP4361AuthProvider(provider, signer, {
+  domain: 'localhost',
+  uri: 'http://localhost:3000',
+});
+```
+{% endtab %}
+
+{% tab title="Serialization" %}
+**Browser:** `messageKit` often stays in memory.
+
+**Node.js:** Use binary serialization for storage or transmission.
+```typescript
+const bytes = messageKit.toBytes();
+const restored = ThresholdMessageKit.fromBytes(bytes);
+```
+{% endtab %}
+{% endtabs %}
+
+## Next steps
 
 * Browse all [condition types](../taco-sdk/references/conditions/) to define more complex access rules
 * See the [full Node.js example](https://github.com/nucypher/taco-web/tree/main/examples/taco/nodejs) in the taco-web repo


### PR DESCRIPTION
## Summary
- Adds a dedicated Node.js quickstart alongside the existing browser quickstart
- Covers `JsonRpcProvider` setup, private key wallets, SIWE params for non-browser, and `ThresholdMessageKit` serialization
- Explains the provider confusion (Polygon Amoy for DKG contracts, not your app chain)
- Based on the existing `examples/taco/nodejs` in taco-web

Motivated by findings in https://github.com/nucypher/combat-training/pull/1 — agents and CLI developers consistently fail on the browser-centric quickstart.