### PR TITLE
Clarify provider role, ritual IDs, and ethers v5 requirement

### DIFF
--- a/for-developers/access-control/quickstart-testnet.md
+++ b/for-developers/access-control/quickstart-testnet.md
@@ -19,6 +19,10 @@ Install `taco` , `taco-auth`, and `ethers` with your favorite package manager:
 <pre class="language-bash"><code class="lang-bash"><strong>$ npm install @nucypher/taco @nucypher/taco-auth ethers@5.7.2
 </strong></code></pre>
 
+{% hint style="warning" %}
+TACo currently requires **ethers v5**. The API is not compatible with ethers v6 (`ethers.BrowserProvider`, `ethers.JsonRpcProvider` without the `providers` namespace, etc.). If your project uses ethers v6, install v5 alongside it.
+{% endhint %}
+
 ### 2. Configuration
 
 To run the code examples below, you will need the `ritualId` encryption parameter. **In production**, your wallet address (encryptor) will also have to be allow-listed for this specific ritual. Please reach out to us [here](https://discord.com/channels/411401661714792449/1344417143659171991) to receive a `ritualId` and allow-list access.\
@@ -29,7 +33,13 @@ Additionally, we have [publicly available testnet rituals](../get-started-with-t
 
 With `ritualId` and [a web3 provider from `ethers`](https://docs.ethers.org/v5/api/providers/#providers-getDefaultProvider), we can `taco.encrypt` our data.&#x20;
 
-In this example, we will use our [`tapir` testnet](../get-started-with-tac.md#threshold-decryption), where you can freely use `ritualId = 6`; A read-only connection to Polygon Amoy is required due to DKG Coordination contracts being stored there. The `signerProvider` is required to [authenticate](../taco-sdk/references/authentication/) the Encryptor.
+In this example, we will use our [`tapir` testnet](../get-started-with-tac.md#threshold-decryption), where you can freely use `ritualId = 6`.
+
+{% hint style="info" %}
+The `polygonProvider` below connects to **Polygon Amoy** — this is where TACo's DKG coordination contracts live. It is **not** your application's chain provider. Your conditions can still target any supported EVM chain (Ethereum, Sepolia, etc.) regardless of this provider.
+{% endhint %}
+
+The `signerProvider` is required to [authenticate](../taco-sdk/references/authentication/) the Encryptor.
 
 <pre class="language-typescript"><code class="lang-typescript">import { initialize, encrypt, conditions, domains } from '@nucypher/taco';
 import { ethers } from "ethers";

--- a/for-developers/access-control/quickstart-testnet.md
+++ b/for-developers/access-control/quickstart-testnet.md
@@ -20,7 +20,7 @@ Install `taco` , `taco-auth`, and `ethers` with your favorite package manager:
 </strong></code></pre>
 
 {% hint style="warning" %}
-TACo currently requires **ethers v5**. The API is not compatible with ethers v6 (`ethers.BrowserProvider`, `ethers.JsonRpcProvider` without the `providers` namespace, etc.). If your project uses ethers v6, install v5 alongside it.
+TACo currently requires **ethers v5**. The API is not compatible with ethers v6 (`ethers.BrowserProvider`, `ethers.JsonRpcProvider` without the `providers` namespace, etc.).
 {% endhint %}
 
 ### 2. Configuration

--- a/for-developers/access-control/taco-integration/README.md
+++ b/for-developers/access-control/taco-integration/README.md
@@ -38,7 +38,7 @@ yarn add ethers@5.7.2 @metamask/detect-provider
 ```
 
 {% hint style="warning" %}
-TACo currently requires **ethers v5**. The API is not compatible with ethers v6. If your project uses ethers v6, install v5 alongside it.
+TACo currently requires **ethers v5**. The API is not compatible with ethers v6.
 {% endhint %}
 
 To use `taco`, we have to call `initialize` method first. This method takes care of initializing the WASM module for `taco` dependencies.

--- a/for-developers/access-control/taco-integration/README.md
+++ b/for-developers/access-control/taco-integration/README.md
@@ -37,6 +37,10 @@ For this guide, we'll need a few extra packages:
 yarn add ethers@5.7.2 @metamask/detect-provider
 ```
 
+{% hint style="warning" %}
+TACo currently requires **ethers v5**. The API is not compatible with ethers v6. If your project uses ethers v6, install v5 alongside it.
+{% endhint %}
+
 To use `taco`, we have to call `initialize` method first. This method takes care of initializing the WASM module for `taco` dependencies.
 
 ```typescript

--- a/for-developers/get-started-with-tac.md
+++ b/for-developers/get-started-with-tac.md
@@ -28,6 +28,28 @@ We encourage you to use the `TESTNET` domain for developing TACo-based apps, and
 Both `DEVNET` and `TESTNET` domains are unsuitable for use in a production setting. Testnet domains have no trust minimization or stability guarantees, which makes them unfit for production or real-world data payloads. Learn more about this in the trust assumptions [section](../for-product-leads/trust-assumptions/).
 {% endhint %}
 
+## Quick reference
+
+Copy-paste these values to get started immediately:
+
+```typescript
+import { domains } from '@nucypher/taco';
+
+// TAPIR (stable testnet) — recommended for development
+const domain = domains.TESTNET;
+const ritualId = 6;  // Open ritual, no encryptor allowlist needed
+
+// Provider must connect to Polygon Amoy (where DKG contracts live)
+// This is NOT your application's chain — it's TACo infrastructure
+const provider = new ethers.providers.JsonRpcProvider(
+  'https://polygon-amoy.drpc.org'  // Any Amoy RPC works
+);
+```
+
+{% hint style="warning" %}
+The `provider` passed to `encrypt()` and `decrypt()` reads DKG coordination contracts on the L2 chain (Polygon Amoy for testnets, Polygon for mainnet). It does **not** determine which chains your conditions can target — conditions can reference any supported EVM chain regardless of which L2 the DKG contracts live on.
+{% endhint %}
+
 ## Testnet configuration
 
 ### Threshold Decryption

--- a/for-developers/get-started-with-tac.md
+++ b/for-developers/get-started-with-tac.md
@@ -30,7 +30,7 @@ Both `DEVNET` and `TESTNET` domains are unsuitable for use in a production setti
 
 ## Quick reference
 
-Copy-paste these values to get started immediately:
+Copy-paste these values to get started immediately. These examples use **ethers v5** (`npm install ethers@5.7.2`), which TACo currently requires.
 
 {% tabs %}
 {% tab title="TAPIR (recommended)" %}

--- a/for-developers/get-started-with-tac.md
+++ b/for-developers/get-started-with-tac.md
@@ -32,10 +32,12 @@ Both `DEVNET` and `TESTNET` domains are unsuitable for use in a production setti
 
 Copy-paste these values to get started immediately:
 
+{% tabs %}
+{% tab title="TAPIR (recommended)" %}
 ```typescript
 import { domains } from '@nucypher/taco';
+import { ethers } from 'ethers';
 
-// TAPIR (stable testnet) — recommended for development
 const domain = domains.TESTNET;
 const ritualId = 6;  // Open ritual, no encryptor allowlist needed
 
@@ -45,6 +47,23 @@ const provider = new ethers.providers.JsonRpcProvider(
   'https://polygon-amoy.drpc.org'  // Any Amoy RPC works
 );
 ```
+{% endtab %}
+
+{% tab title="Lynx (bleeding-edge)" %}
+```typescript
+import { domains } from '@nucypher/taco';
+import { ethers } from 'ethers';
+
+const domain = domains.DEVNET;
+const ritualId = 27;  // Open ritual, no encryptor allowlist needed
+
+// Provider must connect to Polygon Amoy (where DKG contracts live)
+const provider = new ethers.providers.JsonRpcProvider(
+  'https://polygon-amoy.drpc.org'
+);
+```
+{% endtab %}
+{% endtabs %}
 
 {% hint style="warning" %}
 The `provider` passed to `encrypt()` and `decrypt()` reads DKG coordination contracts on the L2 chain (Polygon Amoy for testnets, Polygon for mainnet). It does **not** determine which chains your conditions can target — conditions can reference any supported EVM chain regardless of which L2 the DKG contracts live on.

--- a/for-developers/get-started-with-tac.md
+++ b/for-developers/get-started-with-tac.md
@@ -66,7 +66,7 @@ const provider = new ethers.providers.JsonRpcProvider(
 {% endtabs %}
 
 {% hint style="warning" %}
-The `provider` passed to `encrypt()` and `decrypt()` reads DKG coordination contracts on the L2 chain (Polygon Amoy for testnets, Polygon for mainnet). It does **not** determine which chains your conditions can target — conditions can reference any supported EVM chain regardless of which L2 the DKG contracts live on.
+The `provider` configured above reads DKG coordination contracts on the L2 chain (Polygon Amoy for testnets, Polygon for mainnet). It is required by `encrypt()` and can also be used with `decrypt()`. In browser contexts, `decrypt()` typically uses a `Web3Provider` connected to the user's wallet instead. Neither provider determines which chains your conditions can target — conditions can reference any supported EVM chain.
 {% endhint %}
 
 ## Testnet configuration


### PR DESCRIPTION
## Summary
- Adds "Quick Reference" code block to testnets page with copy-pasteable config (domain, ritualId, provider)
- Explains that the provider reads DKG contracts on Polygon Amoy — not the application's chain
- Adds ethers v5 requirement warnings to quickstart and integration pages
- Adds provider explanation hint to quickstart encrypt step

These are the most common failure points for new developers and agents integrating TACo. See https://github.com/nucypher/combat-training/pull/1 and https://github.com/nucypher/taco-web/issues/765 for context.