### PR TITLE
Fix incorrect import paths and variable shadowing in examples

### DIFF
--- a/for-developers/access-control/taco-integration/README.md
+++ b/for-developers/access-control/taco-integration/README.md
@@ -72,12 +72,12 @@ We can create more complex conditions by combining them with `CompoundCondition`
 ```typescript
 import { conditions } from '@nucypher/taco';
 
-const conditions = new conditions.compound.CompoundCondition({
-  operator: 'and'
+const combined = new conditions.compound.CompoundCondition({
+  operator: 'and',
   operands: [
-    NFTOwnership,
+    ownsNFT,
     // Other conditions can be added here
-  ]
+  ],
 });
 ```
 

--- a/for-developers/taco-sdk/references/authentication/conditioncontext-and-context-variables.md
+++ b/for-developers/taco-sdk/references/authentication/conditioncontext-and-context-variables.md
@@ -42,7 +42,7 @@ Let's take a look at this `ContractConditon` example:
 ```typescript
 import { conditions } from '@nucypher/taco';
 
-const ownsNFTRaw = new conditions.contract.ContractCondition({
+const ownsNFTRaw = new conditions.base.contract.ContractCondition({
   method: 'balanceOf',
   parameters: [':userAddress'], // <- A context variable
   standardContractType: 'ERC721',


### PR DESCRIPTION
## Summary
- `conditions.contract.ContractCondition` → `conditions.base.contract.ContractCondition` (ConditionContext page)
- `const conditions = new conditions.compound.CompoundCondition` → `const combined = ...` (variable shadowing, integration page)
- Fix missing comma in CompoundCondition operator field
- Fix reference to undefined `NFTOwnership` → `ownsNFT`

These will trip up any agent (or developer) copy-pasting from the docs.